### PR TITLE
refactor: change signature requirements for justifications and user settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "commitmsg": "kleros-scripts commitmsg",
     "cz": "kleros-scripts cz",
     "invoke": "env-cmd ./.env serverless invoke -l -f",
-    "build": "docker run --rm -v $PWD:/data -w /data node:8 npm rebuild scrypt",
+    "build": "docker run --rm -v $PWD:/data -w /data lambci/lambda:build-nodejs8.10 npm rebuild scrypt",
     "deploy:function": "env-cmd ./.env serverless deploy function -f",
     "deploy:staging": "env-cmd ./.env serverless deploy",
     "deploy": "env-cmd ./.env serverless deploy -s production"

--- a/serverless.yml
+++ b/serverless.yml
@@ -251,7 +251,12 @@ functions:
       - {
           Effect: Allow,
           Action: ['dynamodb:Query'],
-          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/justifications',
+          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/kovan-justifications',
+        }
+      - {
+          Effect: Allow,
+          Action: ['dynamodb:Query'],
+          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/mainnet-justifications',
         }
     documentation:
       summary: 'Get justifications for a dispute round.'
@@ -290,7 +295,12 @@ functions:
       - {
           Effect: Allow,
           Action: ['dynamodb:PutItem'],
-          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/justifications',
+          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/kovan-justifications',
+        }
+      - {
+          Effect: Allow,
+          Action: ['dynamodb:PutItem'],
+          Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/mainnet-justifications',
         }
     documentation:
       summary: 'Put justification for a vote.'

--- a/src/court/justifications.js
+++ b/src/court/justifications.js
@@ -17,7 +17,7 @@ module.exports.get = async (event, _context, callback) => {
             }
           },
           KeyConditionExpression: 'disputeIDAndAppeal = :disputeIDAndAppeal',
-          TableName: 'justifications'
+          TableName: `${payload.network}-justifications`
         })
       }
     })
@@ -32,71 +32,63 @@ module.exports.put = async (event, _context, callback) => {
     process.env.KLEROS_LIQUID_ADDRESS
   )
 
-  // Validate signature
   const payload = JSON.parse(event.body).payload
-  try {
-    if (
-      (await web3.eth.accounts.recover(
-        JSON.stringify(payload.justification),
-        payload.signature
-      )) !==
-      (await dynamoDB.getItem({
-        Key: { address: { S: payload.address } },
-        TableName: 'user-settings',
-        ProjectionExpression: 'derivedAccountAddress'
-      })).Item.derivedAccountAddress.S
-    )
-      throw new Error(
-        "Signature does not match the supplied address' derived account address for justifications."
-      )
-  } catch (err) {
-    console.error(err)
+
+  // Verify votes belong to user
+  const dispute = await klerosLiquid.methods.getDispute(
+    payload.justification.disputeID
+  ).call()
+
+  // Get number of votes in current round
+  const votesInRound = dispute.votesLengths[payload.justification.appeal]
+
+  let drawn = false
+  let voteID
+  for (let i = 0; i < Number(votesInRound); i++) {
+    const vote = await klerosLiquid.methods
+      .getVote(payload.justification.disputeID, payload.justification.appeal, i)
+      .call()
+    if (vote.account === payload.address) {
+      // If voted, can no longer submit justification.
+      if (vote.voted) {
+        return callback(null, {
+          statusCode: 403,
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify({
+            error: 'This address has already cast their vote.'
+          })
+        })
+      }
+      // Once we know address has been drawn we can stop searching.
+      drawn = true
+      voteID = i
+      break
+    }
+  }
+
+  if (!drawn) {
     return callback(null, {
       statusCode: 403,
       headers: { 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify({
-        error:
-          "Signature is invalid or does not match the supplied address' derived account address for justifications."
+        error: 'This address was not drawn.'
       })
     })
   }
 
-  // Verify votes belong to user
-  for (const voteID of payload.justification.voteIDs) {
-    const vote = await klerosLiquid.methods
-      .getVote(
-        payload.justification.disputeID,
-        payload.justification.appeal,
-        voteID
-      )
-      .call()
-    if (vote.account !== payload.address || vote.voted)
-      return callback(null, {
-        statusCode: 403,
-        headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify({
-          error:
-            'Not all of the supplied vote IDs belong to the supplied address and are not cast.'
-        })
-      })
-  }
-
-  // Save justification
+  // Save justification.
   await dynamoDB.putItem({
     Item: {
       disputeIDAndAppeal: {
         S: `${payload.justification.disputeID}-${payload.justification.appeal}`
       },
-      voteID: {
-        N: String(
-          payload.justification.voteIDs[
-            payload.justification.voteIDs.length - 1
-          ]
-        )
+      address: {
+        S: payload.address
       },
+      voteID: { N: String(voteID) },
       justification: { S: payload.justification.justification }
     },
-    TableName: 'justifications'
+    TableName: `${payload.network}-justifications`
   })
   callback(null, {
     statusCode: 200,


### PR DESCRIPTION
- No need for sig for justifications. If vote has been cast then you can no longer submit justification.
- Allow for sig to be from account or derived account for user-settings